### PR TITLE
changing jre version

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
-openjdk-9-jre-headless
+openjdk-11-jdk
 maven


### PR DESCRIPTION
new base image for binder has changed and so a new JDK is needed to install with apt-get